### PR TITLE
deeplabv3の事前学習モデルを使えるようにする

### DIFF
--- a/example/data/classification/videos/test/test.csv
+++ b/example/data/classification/videos/test/test.csv
@@ -1,0 +1,4 @@
+start_time,end_time,class_name
+00:00:01,00:00:02,cat
+00:00:02,00:00:03,flower
+00:00:03,00:00:05,dog

--- a/example/data/classification/videos/train/train.csv
+++ b/example/data/classification/videos/train/train.csv
@@ -1,0 +1,4 @@
+start_time,end_time,class_name
+00:00:01,00:00:02,cat
+00:00:02,00:00:03,flower
+00:00:03,00:00:05,dog

--- a/example/data/classification/videos/validation/validation.csv
+++ b/example/data/classification/videos/validation/validation.csv
@@ -1,0 +1,4 @@
+start_time,end_time,class_name
+00:00:01,00:00:02,cat
+00:00:02,00:00:03,flower
+00:00:03,00:00:05,dog

--- a/example/yamls/segmentation-eval.yaml
+++ b/example/yamls/segmentation-eval.yaml
@@ -17,8 +17,9 @@ train_params:
     batch_size: 8 
     learning_rate: 0.001
     weights_info:
+        task:  # segmentation or classification or None
         classes: # assign only when you use backbone weights
-        weights: 
+        weights: # pascal_voc, cityscapes, or your model path(*.h5)
     augmentation: no
 
 epochs: 2

--- a/example/yamls/segmentation-optuna.yaml
+++ b/example/yamls/segmentation-optuna.yaml
@@ -75,8 +75,9 @@ train_params:
         - 0.00001  # min(10^n)
         - 0.1  # max(10^n)
     weights_info:
+        task:  # segmentation or classification or None
         classes: # assign only when you use backbone weights
-        weights: 
+        weights: # pascal_voc, cityscapes, or your model path(*.h5)
     augmentation:
         # - horizontal_flip
         # - zoom

--- a/example/yamls/segmentation.yaml
+++ b/example/yamls/segmentation.yaml
@@ -52,8 +52,9 @@ train_params:
     batch_size: 8 
     learning_rate: 0.001
     weights_info: 
+        task:  # segmentation or classification or None
         classes: # assign only when you use backbone weights
-        weights: 
+        weights:  # pascal_voc, cityscapes, or your model path(*.h5)
     augmentation:
         HorizontalFlip:
         IAAPerspective:

--- a/farmer/ncc/models/dilated_xception.py
+++ b/farmer/ncc/models/dilated_xception.py
@@ -125,18 +125,19 @@ def DilatedXception(classes=10, input_tensor=None, input_shape=(512, 512, 3), we
 
         elif weights_info["weights"] in {'pascal_voc', 'cityscapes', None}:
             weights = weights_info["weights"]
-        
+
         elif os.path.exists(weights_info["weights"]):
             weights = weights_info["weights"]
             if weights_info.get("classes") is not None:
+                # overwrite nb_classes for load classification model
                 classes = int(weights_info["classes"])
-        
+
         else:
             raise ValueError('The `weights` should be either '
-                            '`None` (random initialization), `pascal_voc`, `cityscapes`, '
-                            'original weights path (pre-training on original data), '
-                            'or the path to the weights file to be loaded and'
-                            '`classes` should be number of original weights output units')
+                             '`None` (random initialization), `pascal_voc`, `cityscapes`, '
+                             'original weights path (pre-training on original data), '
+                             'or the path to the weights file to be loaded and'
+                             '`classes` should be number of original weights output units')
     else:
         weights = 'imagenet'
         if classes is None:
@@ -157,7 +158,7 @@ def DilatedXception(classes=10, input_tensor=None, input_shape=(512, 512, 3), we
         exit_block_rates = (1, 2)
 
     x = Conv2D(32, (3, 3), strides=(2, 2),
-                name='entry_flow_conv1_1', use_bias=False, padding='same')(img_input)
+               name='entry_flow_conv1_1', use_bias=False, padding='same')(img_input)
     x = BatchNormalization(name='entry_flow_conv1_1_BN')(x)
     x = Activation('relu')(x)
 
@@ -166,30 +167,30 @@ def DilatedXception(classes=10, input_tensor=None, input_shape=(512, 512, 3), we
     x = Activation('relu')(x)
 
     x, _ = _xception_block(x, [128, 128, 128], 'entry_flow_block1',
-                        skip_connection_type='conv', stride=2,
-                        depth_activation=False)
+                           skip_connection_type='conv', stride=2,
+                           depth_activation=False)
     x, skip = _xception_block(x, [256, 256, 256], 'entry_flow_block2',
-                                skip_connection_type='conv', stride=2,
-                                depth_activation=False)
+                              skip_connection_type='conv', stride=2,
+                              depth_activation=False)
 
     x, _ = _xception_block(x, [728, 728, 728], 'entry_flow_block3',
-                        skip_connection_type='conv', stride=entry_block3_stride,
-                        depth_activation=False)
+                           skip_connection_type='conv', stride=entry_block3_stride,
+                           depth_activation=False)
     for i in range(16):
         x, _ = _xception_block(x, [728, 728, 728], 'middle_flow_unit_{}'.format(i + 1),
-                            skip_connection_type='sum', stride=1, rate=middle_block_rate,
-                            depth_activation=False)
+                               skip_connection_type='sum', stride=1, rate=middle_block_rate,
+                               depth_activation=False)
 
     x, _ = _xception_block(x, [728, 1024, 1024], 'exit_flow_block1',
-                        skip_connection_type='conv', stride=1, rate=exit_block_rates[0],
-                        depth_activation=False)
+                           skip_connection_type='conv', stride=1, rate=exit_block_rates[0],
+                           depth_activation=False)
     x, _ = _xception_block(x, [1536, 1536, 2048], 'exit_flow_block2',
-                        skip_connection_type='none', stride=1, rate=exit_block_rates[1],
-                        depth_activation=True)
+                           skip_connection_type='none', stride=1, rate=exit_block_rates[1],
+                           depth_activation=True)
 
     x = GlobalAveragePooling2D()(x)
     x = Dense(classes, activation='softmax')(x)
-    
+
     # Ensure that the model takes into account
     # any potential predecessors of `input_tensor`.
     if input_tensor is not None:
@@ -202,20 +203,24 @@ def DilatedXception(classes=10, input_tensor=None, input_shape=(512, 512, 3), we
 
     # Load weights.
     if not (weights in {'imagenet', 'pascal_voc', 'cityscapes', None}):
-        if weights_info.get("classes") is not None:
-            model.load_weights(weights)
+        # distinct between classification model and segmentation model
+        if weights_info.get('task') is None or weights_info.get('task') == 'classification':
+            if weights_info.get("classes") is not None:
+                # set weights if different number of classes
+                model.load_weights(weights)
 
     # get model before FC layer
     if not include_top:
         model = Model(
-            inputs=model.input, 
+            inputs=model.input,
             outputs=model.get_layer(index=-3).output
         )
-    
+
     if return_skip:
         return model, skip
     else:
         return model
+
 
 def dilated_xception(nb_classes, height=512, width=512, weights_info=None):
     base_model = DilatedXception(
@@ -230,4 +235,3 @@ def dilated_xception(nb_classes, height=512, width=512, weights_info=None):
     model = Model(base_model.input, predictions)
 
     return model
-


### PR DESCRIPTION
## 概要
- DeeplabV3+で学習したモデルを事前学習モデルとして、クラス数の異なる他のデータセットでfine-tuningできるようにする
- yamlのweights_info: weightsにモデル（h5形式）の**絶対パス**を書く

## 変更点
- yamlのweights_infoに `task` を追加
    - `classification` か `segmentation` を記載する必要あり
        - 何も書かない場合（ `None` の場合）、従来通りclassificationのモデルとして読み込まれる
- backboneのdilated_xceptionとmobilenetv2にweights_infoの条件分岐を追加
- load_weightしたあとにdeeplabv3のheadを新しくbuildするように分岐

## 問題点・懸念点
- yamlの設定が変わったので注意
- 従来はweightsがNoneの場合はpascal_vocが読まれたが、このfeatureでは**pascal_vocと明記しないと読まれない！！**

### パターン1: 事前学習なし
- weights_infoは全てNoneとする
```yaml
    weights_info: 
        task:  
        classes: 
        weights:  
```

### パターン2: pascal_vocを使用する
- weightsに `pascal_voc` と記載
- taskに `segmentation` と記載してもしなくても良い
```yaml
    weights_info: 
        task:  
        classes: 
        weights:  pascal_voc
```

### パターン3: 自分のclassificationモデルをbackboneとしてを使用する
- taskに `classification` を記載
- weightsにモデルの**絶対パス**を記載
- classesに backboneに使用するモデルのクラス数を記載（今回学習したいクラス数ではない）
```yaml
    weights_info: 
        task:  classification
        classes: 10  # 10クラスで学習したモデルを使う
        weights: /path/to/your/classification_model.h5
```

### パターン4: 自分のsegmentationモデルを事前学習モデルとして使用する
- taskに `segmentation` を記載
- weightsにモデルの**絶対パス**を記載
- classesに事前学習モデルにおけるクラス数を記載（今回学習したいクラス数ではない）
```yaml
    weights_info: 
        task:  segmentation
        classes: 3  # 3クラスで学習したモデルを使う
        weights:  /path/to/your/segmentation_model.h5
```