### PR TITLE
change loss parameter callback

### DIFF
--- a/example/yamls/segmentation.yaml
+++ b/example/yamls/segmentation.yaml
@@ -20,37 +20,51 @@ train_params:
     activation: softmax
     optimizer: adam
     loss:
-      functions:
-        CategoricalFocalLoss:
-            alpha: 
-                0: 1.0
-                1: 1.0
-                2: 2.0
-                3: 3.0
-            gamma: 5.0
-            class_weights: 
-                0: 0.0
-                1: 1.0
-                2: 2.0
-                3: 3.0
-        DiceLoss:
-            beta:
-                0: 1.0
-                1: 1.0
-                2: 2.0
-                3: 3.0
-            class_weights: 
-                0: 0.0
-                1: 1.0
-                2: 2.0
-                3: 3.0
-      param_scheduler:
-        dice_loss:
-            beta:
+        functions:
+            CategoricalFocalLoss:
+                alpha: 
+                    0: 1.0
+                    1: 1.0
+                    2: 2.0
+                    3: 3.0
+                gamma: 5.0
+                class_weights: 
+                    0: 0.0
+                    1: 1.0
+                    2: 2.0
+                    3: 3.0
+            DiceLoss:
+                beta:
+                    0: 1.0
+                    1: 1.0
+                    2: 2.0
+                    3: 3.0
+                class_weights: 
+                    0: 0.0
+                    1: 1.0
+                    2: 2.0
+                    3: 3.0
+        param_scheduler:
+            dice_loss:
+                beta:
+                    schedule_fn: linear
+                    params:
+                        delta: -0.3
+                        min: 0.01
+        loss_weights:
+            l1: 1.
+            l2: 0.
+        loss_weights_scheduler:
+            l1:
                 schedule_fn: linear
                 params:
-                    delta: -0.3
-                    min: 0.01
+                    delta: -0.1
+                    min: 0.
+            l2:
+                schedule_fn: linear
+                params:
+                    delta: 0.1
+                    max: 1.
     scheduler:
         functions:
             CosineDecay:

--- a/example/yamls/segmentation.yaml
+++ b/example/yamls/segmentation.yaml
@@ -44,6 +44,13 @@ train_params:
                 1: 1.0
                 2: 2.0
                 3: 3.0
+      param_scheduler:
+        dice_loss:
+            beta:
+                schedule_fn: linear
+                params:
+                    delta: -0.3
+                    min: 0.01
     scheduler:
         functions:
             CosineDecay:
@@ -75,9 +82,9 @@ train_params:
                 p: 1  # percentage of function inside 'OneOf'
             p: 1  # percetage of 'OneOf'
     augmix: yes            
-epochs: 2
-segmentation_val_step: 2
-n_trials: 3
+epochs: 5
+segmentation_val_step: 1
+n_trials: 1
 width: 512
 height: 256
 input_dir: image
@@ -97,7 +104,7 @@ train_colors:
 early_stopping: yes # yes if using early_stopping to interruption
 patience: 5
 monitor: val_loss
-mlflow: True
+mlflow: False
 experiment_name: test_experiment
 run_name: segmentation_test
 user_name: test_user

--- a/farmer/domain/tasks/build_model_task.py
+++ b/farmer/domain/tasks/build_model_task.py
@@ -216,19 +216,17 @@ class BuildModelTask:
             print('------------------')
             print('Loss:', loss_funcs.keys())
             print('------------------')
+            
+            loss_container = list()
+            
             if task_id == Task.CLASSIFICATION:
                 for i, loss_func in enumerate(loss_funcs.items()):
                     loss_name, params = loss_func
-                    if i == 0:
-                        if params is None:
-                            loss = getattr(keras.losses, loss_name)()
-                        else:
-                            loss = getattr(keras.losses, loss_name)(**params)
+                    if params is None:
+                        loss_instance = getattr(keras.losses, loss_name)()
                     else:
-                        if params is None:
-                            loss += getattr(keras.losses, loss_name)()
-                        else:
-                            loss += getattr(keras.losses, loss_name)(**params)
+                        loss_instance = getattr(keras.losses, loss_name)(**params)
+                    loss_container.append(loss_instance)
                 metrics = ["acc"]
 
             elif task_id == Task.SEMANTIC_SEGMENTATION:
@@ -246,16 +244,12 @@ class BuildModelTask:
                             isinstance(params["beta"], dict) ):
                             params["beta"] = np.array(
                                 list(params["beta"].values()) )
-                    if i == 0:
-                        if params is None:
-                            loss = getattr(losses, loss_name)()
-                        else:
-                            loss = getattr(losses, loss_name)(**params)
+                    if params is None:
+                        loss_instance = getattr(losses, loss_name)()
                     else:
-                        if params is None:
-                            loss += getattr(losses, loss_name)()
-                        else:
-                            loss += getattr(losses, loss_name)(**params)
+                        loss_instance = getattr(losses, loss_name)(**params)
+                    loss_container.append(loss_instance)
+
                 metrics = [
                     segmentation_models.metrics.IOUScore(
                         class_indexes=list(range(1, self.config.nb_classes))),
@@ -263,5 +257,13 @@ class BuildModelTask:
                         class_indexes=list(range(1, self.config.nb_classes)))
                     ],
 
-            model.compile(optimizer, loss, metrics)
+            # compound loss
+            if len(loss_container) > 1:
+                loss_weights = loss.get("loss_weights", dict())
+                w_l1 = loss_weights.get('l1', 1.)
+                w_l2 = loss_weights.get('l2', 1.)
+                loss_instance = losses.CompoundLoss(loss_container[0], loss_container[1], w_l1, w_l2)
+
+            model.compile(optimizer, loss_instance, metrics)
+
         return model

--- a/farmer/domain/tasks/train_task.py
+++ b/farmer/domain/tasks/train_task.py
@@ -4,6 +4,7 @@ from tensorflow import keras
 import tensorflow as tf
 from farmer import ncc
 from farmer.ncc import schedulers
+from farmer.ncc.callbacks import keras_callbacks
 from optuna.integration import TFKerasPruningCallback
 
 
@@ -175,6 +176,13 @@ class TrainTask:
             )
             callbacks.append(early_stopping)
 
+        # Loss Param Scheduler
+        loss_param_scheduler = self.config.train_params.loss.get('param_scheduler')
+        
+        if loss_param_scheduler:
+            for loss_name, target in loss_param_scheduler.items():
+                callbacks.append(keras_callbacks.LossParamScheduler(base_model, loss_name, target))
+            
         return callbacks
 
     def _do_model_optimization_task(

--- a/farmer/domain/tasks/train_task.py
+++ b/farmer/domain/tasks/train_task.py
@@ -182,7 +182,13 @@ class TrainTask:
         if loss_param_scheduler:
             for loss_name, target in loss_param_scheduler.items():
                 callbacks.append(keras_callbacks.LossParamScheduler(base_model, loss_name, target))
-            
+        
+        # Loss Weights Scheduler
+        loss_weights_scheduler = self.config.train_params.loss.get('loss_weights_scheduler', dict())
+        
+        if loss_weights_scheduler:
+            callbacks.append(keras_callbacks.LossWeightsScheduler(base_model, loss_weights_scheduler))
+        
         return callbacks
 
     def _do_model_optimization_task(

--- a/farmer/ncc/callbacks/__init__.py
+++ b/farmer/ncc/callbacks/__init__.py
@@ -1,2 +1,3 @@
 from .keras_callbacks import *
 from .keras_prune import KerasPruningCallback
+from .functional import *

--- a/farmer/ncc/callbacks/functional.py
+++ b/farmer/ncc/callbacks/functional.py
@@ -1,0 +1,14 @@
+import numpy as np
+
+def linear(param, epoch, delta=0.01, min=0.01, max=None):
+    updated = True
+    return updated, np.clip(param + delta, min, max)
+
+def step_delta(param, epoch, delta=0.01, step=1, min=0.01, max=None):
+    updated = False
+    if (epoch + 1) % step == 0:
+        updated = True
+        return updated, np.clip(param + delta, min, max)
+    else:
+        return updated, param
+

--- a/farmer/ncc/callbacks/keras_callbacks.py
+++ b/farmer/ncc/callbacks/keras_callbacks.py
@@ -38,8 +38,7 @@ class LossWeightsScheduler(keras.callbacks.Callback):
                 update_fn = getattr(F, scheduler['schedule_fn'])
                 self.scheduler.append((f'w_{loss_index}', update_fn, scheduler['params']))
             else:
-                print(f'{model.loss.__name__} does not have attribute: w_{loss_index}. Loss must be <losses.CompoundLoss>')
-                raise AttributeError
+                raise AttributeError(f'{model.loss.__name__} does not have attribute: w_{loss_index}. Loss must be <losses.CompoundLoss>')
 
     def on_epoch_end(self, epoch, logs={}):
         for (param_name, update_fn, update_fn_params) in self.scheduler:
@@ -87,8 +86,7 @@ class LossParamScheduler(keras.callbacks.Callback):
                 update_fn = getattr(F, scheduler['schedule_fn'])
                 self.scheduler.append((param_name, update_fn, scheduler['params']))
             else:
-                print(f'{self.loss.__name__} does not have attribute: {param_name}')
-                raise AttributeError
+                raise AttributeError(f'{self.loss.__name__} does not have attribute: {param_name}')
     
     def loss_instance(self, model):
         # compound loss
@@ -98,15 +96,13 @@ class LossParamScheduler(keras.callbacks.Callback):
             elif model.loss.l2.__name__ == self.loss_name:
                 cls = model.loss.l2
             else:
-                print(f'not compiled loss: {self.loss_name}')
-                raise NotImplementedError
+                raise NotImplementedError(f'not compiled loss: {self.loss_name}')
         # single loss
         else:
             if model.loss.__name__ == self.loss_name:
                 cls = model.loss
             else:
-                print(f'not compiled loss: {self.loss_name}')
-                raise NotImplementedError
+                raise NotImplementedError(f'not compiled loss: {self.loss_name}')
         return cls
     
     def on_epoch_end(self, epoch, logs={}):

--- a/farmer/ncc/losses/losses.py
+++ b/farmer/ncc/losses/losses.py
@@ -10,9 +10,12 @@ segmentation_models.set_framework('tf.keras')
 class DiceLoss(Loss):
     def __init__(self, beta=1, class_weights=None, flooding_level=0.):
         super().__init__(name='dice_loss')
-        self.beta = beta
-        self.class_weights = class_weights if class_weights is not None else 1
-        self.flooding_level = flooding_level
+        self.beta = tf.Variable(beta, dtype=tf.float32)
+        if class_weights is not None:
+            self.class_weights = tf.Variable(class_weights, dtype=tf.float32) 
+        else:
+            self.class_weights = tf.Variable(1, dtype=tf.float32)
+        self.flooding_level = tf.Variable(flooding_level, dtype=tf.float32)
 
     def __call__(self, gt, pr):
         return F.flooding(F.dice_loss(
@@ -26,8 +29,11 @@ class DiceLoss(Loss):
 class JaccardLoss(Loss):
     def __init__(self, class_weights=None, flooding_level=0.):
         super().__init__(name='jaccard_loss')
-        self.class_weights = class_weights if class_weights is not None else 1
-        self.flooding_level = flooding_level
+        if class_weights is not None:
+            self.class_weights = tf.Variable(class_weights, dtype=tf.float32) 
+        else:
+            self.class_weights = tf.Variable(1, dtype=tf.float32)
+        self.flooding_level = tf.Variable(flooding_level, dtype=tf.float32)
 
     def __call__(self, gt, pr):
         return F.flooding(F.jaccard_loss(
@@ -40,10 +46,13 @@ class JaccardLoss(Loss):
 class TverskyLoss(Loss):
     def __init__(self, alpha=0.45, beta=0.55, class_weights=None, flooding_level=0.):
         super().__init__(name='tversky_loss')
-        self.alpha = alpha
-        self.beta = beta
-        self.class_weights = class_weights if class_weights is not None else 1.
-        self.flooding_level = flooding_level
+        self.alpha = tf.Variable(alpha, dtype=tf.float32)
+        self.beta = tf.Variable(beta, dtype=tf.float32)
+        if class_weights is not None:
+            self.class_weights = tf.Variable(class_weights, dtype=tf.float32) 
+        else:
+            self.class_weights = tf.Variable(1, dtype=tf.float32)
+        self.flooding_level = tf.Variable(flooding_level, dtype=tf.float32)
 
     def __call__(self, gt, pr):
         return F.flooding(F.tversky_loss(
@@ -58,11 +67,14 @@ class TverskyLoss(Loss):
 class FocalTverskyLoss(Loss):
     def __init__(self, alpha=0.45, beta=0.55, gamma=2.5, class_weights=None, flooding_level=0.):
         super().__init__(name='focal_tversky_loss')
-        self.alpha = alpha
-        self.beta = beta
-        self.gamma = gamma
-        self.class_weights = class_weights if class_weights is not None else 1.
-        self.flooding_level = flooding_level
+        self.alpha = tf.Variable(alpha, dtype=tf.float32)
+        self.beta = tf.Variable(beta, dtype=tf.float32)
+        self.gamma = tf.Variable(gamma, dtype=tf.float32)
+        if class_weights is not None:
+            self.class_weights = tf.Variable(class_weights, dtype=tf.float32) 
+        else:
+            self.class_weights = tf.Variable(1, dtype=tf.float32)
+        self.flooding_level = tf.Variable(flooding_level, dtype=tf.float32)
 
     def __call__(self, gt, pr):
         return F.flooding(F.focal_tversky_loss(
@@ -78,10 +90,13 @@ class FocalTverskyLoss(Loss):
 class CategoricalFocalLoss(Loss):
     def __init__(self, alpha=0.25, gamma=2., class_weights=None, flooding_level=0.):
         super().__init__(name='categorical_focal_loss')
-        self.alpha = alpha
-        self.gamma = gamma
-        self.class_weights = class_weights if class_weights is not None else 1.
-        self.flooding_level = flooding_level
+        self.alpha = tf.Variable(alpha, dtype=tf.float32)
+        self.gamma = tf.Variable(gamma, dtype=tf.float32)
+        if class_weights is not None:
+            self.class_weights = tf.Variable(class_weights, dtype=tf.float32) 
+        else:
+            self.class_weights = tf.Variable(1, dtype=tf.float32)
+        self.flooding_level = tf.Variable(flooding_level, dtype=tf.float32)
 
     def __call__(self, gt, pr):
         return F.flooding(F.categorical_focal_loss(
@@ -96,9 +111,12 @@ class CategoricalFocalLoss(Loss):
 class LogCoshDiceLoss(Loss):
     def __init__(self, beta=1, class_weights=None, flooding_level=0.):
         super().__init__(name='log_cosh_dice_loss')
-        self.beta = beta
-        self.class_weights = class_weights if class_weights is not None else 1
-        self.flooding_level = flooding_level
+        self.beta = tf.Variable(beta, dtype=tf.float32)
+        if class_weights is not None:
+            self.class_weights = tf.Variable(class_weights, dtype=tf.float32) 
+        else:
+            self.class_weights = tf.Variable(1, dtype=tf.float32)
+        self.flooding_level = tf.Variable(flooding_level, dtype=tf.float32)
 
     def __call__(self, gt, pr):
         return F.flooding(F.log_cosh_dice_loss(
@@ -112,10 +130,13 @@ class LogCoshDiceLoss(Loss):
 class LogCoshTverskyLoss(Loss):
     def __init__(self, alpha=0.3, beta=0.7, class_weights=None, flooding_level=0.):
         super().__init__(name='log_cosh_tversky_loss')
-        self.alpha = alpha
-        self.beta = beta
-        self.class_weights = class_weights if class_weights is not None else 1.
-        self.flooding_level = flooding_level
+        self.alpha = tf.Variable(alpha, dtype=tf.float32)
+        self.beta = tf.Variable(beta, dtype=tf.float32)
+        if class_weights is not None:
+            self.class_weights = tf.Variable(class_weights, dtype=tf.float32) 
+        else:
+            self.class_weights = tf.Variable(1, dtype=tf.float32)
+        self.flooding_level = tf.Variable(flooding_level, dtype=tf.float32)
 
     def __call__(self, gt, pr):
         return F.flooding(F.log_cosh_tversky_loss(
@@ -130,11 +151,14 @@ class LogCoshTverskyLoss(Loss):
 class LogCoshFocalTverskyLoss(Loss):
     def __init__(self, alpha=0.3, beta=0.7, gamma=1.3, class_weights=None, flooding_level=0.):
         super().__init__(name='log_cosh_focal_tversky_loss')
-        self.alpha = alpha
-        self.beta = beta
-        self.gamma = gamma
-        self.class_weights = class_weights if class_weights is not None else 1.
-        self.flooding_level = flooding_level
+        self.alpha = tf.Variable(alpha, dtype=tf.float32)
+        self.beta = tf.Variable(beta, dtype=tf.float32)
+        self.gamma = tf.Variable(gamma, dtype=tf.float32)
+        if class_weights is not None:
+            self.class_weights = tf.Variable(class_weights, dtype=tf.float32) 
+        else:
+            self.class_weights = tf.Variable(1, dtype=tf.float32)
+        self.flooding_level = tf.Variable(flooding_level, dtype=tf.float32)
 
     def __call__(self, gt, pr):
         return F.flooding(F.log_cosh_focal_tversky_loss(
@@ -151,7 +175,7 @@ class LogCoshLoss(Loss):
     def __init__(self, base_loss, flooding_level=0., **kwargs):
         super().__init__(name=f'log_cosh_{base_loss}')
         self.loss = getattr(F, base_loss)
-        self.flooding_level = flooding_level
+        self.flooding_level = tf.Variable(flooding_level, dtype=tf.float32)
         self.kwargs = kwargs
 
     def __call__(self, gt, pr):
@@ -164,7 +188,7 @@ class LogCoshLoss(Loss):
 class BoundaryLoss(Loss):
     def __init__(self, flooding_level=0., **kwargs):
         super().__init__(name='boundary_loss')
-        self.flooding_level = flooding_level
+        self.flooding_level = tf.Variable(flooding_level, dtype=tf.float32)
 
     def __call__(self, gt, pr):
         return F.flooding(F.surface_loss(
@@ -175,10 +199,10 @@ class BoundaryLoss(Loss):
 class UnifiedFocalLoss(Loss):
     def __init__(self, weight=0.5, delta=0.6, gamma=0.2, flooding_level=0.):
         super().__init__(name='unified_focal_loss')
-        self.weight = weight
-        self.delta = delta
-        self.gamma = gamma
-        self.flooding_level = flooding_level
+        self.weight = tf.Variable(weight, dtype=tf.float32)
+        self.delta = tf.Variable(delta, dtype=tf.float32)
+        self.gamma = tf.Variable(gamma, dtype=tf.float32)
+        self.flooding_level = tf.Variable(flooding_level, dtype=tf.float32)
 
     def __call__(self, gt, pr):
         return F.flooding(F.unified_focal_loss(

--- a/farmer/ncc/losses/losses.py
+++ b/farmer/ncc/losses/losses.py
@@ -6,6 +6,17 @@ from ..losses import functional as F
 
 segmentation_models.set_framework('tf.keras')
 
+class CompoundLoss(Loss):
+    def __init__(self, l1, l2, w_l1=1., w_l2=1.):
+        name = '{}_plus_{}'.format(l1.__name__, l2.__name__)
+        super().__init__(name=name)
+        self.l1 = l1
+        self.l2 = l2
+        self.w_l1 = tf.Variable(w_l1, dtype=tf.float32)
+        self.w_l2 = tf.Variable(w_l2, dtype=tf.float32)
+
+    def __call__(self, gt, pr):
+        return self.w_l1 * self.l1(gt, pr) + self.w_l2 * self.l2(gt, pr)
 
 class DiceLoss(Loss):
     def __init__(self, beta=1, class_weights=None, flooding_level=0.):


### PR DESCRIPTION
# 概要
- lossのパラメータ, weightをcallbackで変更できるようにする
# 主な変更箇所
- keras_callbacks.py
  - lossのparameterを変更するcallbackクラスを追加
  - loss_weightsを変更するcallbackクラスを追加 (2021/12/27)
- losses.py
  - lossのパラメータをTensor（tf.Variable）に変更
  - 理由：callback内でパラメータを書き換える際、np.arrayの状態で書き換えても(setattr)、lossの計算時に書き換えたパラメータが反映されていなかった。keras.backend.set_valueで書き換えることでlossの計算時に書き換えたパラメータを反映することができたが、set_valueで値を書き換えるためにはパラメータをTensorで保持する必要がある。そのため、lossのパラメータをtf.Variableで持つことにした。
- 複数lossを指定する場合にsegmentation_modelsのSumOfLossesではなくCompoundLossを使用するように変更 (2021/12/27)
  - loss_weightを指定できるようにするため。また、callbackで変更できるようにするため。
- example/yamls/segmentation.yaml
  - callbackでlossのパラメータを変更する際の例を追記
# 動作確認
- farmer/exampleのdetection以外がエラーなく動くことを確認。
- 今回追加したcallbackの片方/両方がyaml指定で動くことを確認。
- LossWeightScheduler
  - CompoundLossのcall時に変更後のweightが適用されていることをログで確認。
- LossParamScheduler
  - example/segmentation.yamlでDiceLossにcallbackを適用し、call時に変更後のbetaが適用されていることをログで確認。