### PR TITLE
recall loss

### DIFF
--- a/farmer/ncc/losses/functional.py
+++ b/farmer/ncc/losses/functional.py
@@ -235,7 +235,7 @@ def active_contour_loss(gt, pr, w_region=1.0, w_region_in=1.0, w_region_out=1.0)
     delta_u = K.abs(delta_x + delta_y) 
 
     length = K.mean(K.sqrt(delta_u + SMOOTH))
-
+    
     """
     region term
     """
@@ -246,3 +246,14 @@ def active_contour_loss(gt, pr, w_region=1.0, w_region_in=1.0, w_region_out=1.0)
     loss = length + w_region * region
 
     return loss
+
+def recall_loss(gt, pr):
+    tp, fp, fn = _tp_fp_fn(gt, pr)
+    recall = tp / (fn + tp)
+    
+    pr = tf.clip_by_value(pr, SMOOTH, 1 - SMOOTH)
+    ce = -gt * K.log(pr)
+    
+    loss = - (1 - recall) * ce
+    
+    return  tf.reduce_mean(loss)

--- a/farmer/ncc/losses/functional.py
+++ b/farmer/ncc/losses/functional.py
@@ -247,13 +247,13 @@ def active_contour_loss(gt, pr, w_region=1.0, w_region_in=1.0, w_region_out=1.0)
 
     return loss
 
-def recall_loss(gt, pr):
+def recall_loss(gt, pr, class_weights=1.):
     tp, fp, fn = _tp_fp_fn(gt, pr)
     recall = tp / (fn + tp)
     
     pr = tf.clip_by_value(pr, SMOOTH, 1 - SMOOTH)
     ce = -gt * K.log(pr)
     
-    loss = - (1 - recall) * ce
+    loss = (1 - recall) * ce * class_weights
     
     return  tf.reduce_mean(loss)

--- a/farmer/ncc/losses/losses.py
+++ b/farmer/ncc/losses/losses.py
@@ -268,5 +268,16 @@ class ActiveContourLoss(Loss):
             pr=pr,
             w_region=self.w_region,
             w_region_in=self.w_region_in,
-            w_region_out=self.w_region_out
+            w_region_out=self.w_region_out,
+        ), self.flooding_level)
+
+class RecallLoss(Loss):
+    def __init__(self, flooding_level=0.):
+        super().__init__(name='recall_loss')
+        self.flooding_level = tf.Variable(flooding_level, dtype=tf.float32)
+    
+    def __call__(self, gt, pr):
+        return F.flooding(F.recall_loss(
+            gt=gt,
+            pr=pr,
         ), self.flooding_level)

--- a/farmer/ncc/losses/losses.py
+++ b/farmer/ncc/losses/losses.py
@@ -272,12 +272,14 @@ class ActiveContourLoss(Loss):
         ), self.flooding_level)
 
 class RecallLoss(Loss):
-    def __init__(self, flooding_level=0.):
+    def __init__(self, class_weights=None, flooding_level=0.):
         super().__init__(name='recall_loss')
+        self.class_weights = class_weights if class_weights is not None else 1
         self.flooding_level = tf.Variable(flooding_level, dtype=tf.float32)
     
     def __call__(self, gt, pr):
         return F.flooding(F.recall_loss(
             gt=gt,
             pr=pr,
+            class_weights=self.class_weights
         ), self.flooding_level)


### PR DESCRIPTION
small classの精度向上のためのLossを提案

各クラスのRecallによって動的に重みをつけたCross Entropy Loss（Recall Loss）を提案
(1-Recall)=False Negative Rateで重み付けしている
 
SynthiaデータセットにおいてRecall LossではCE LossやFocal Lossと比べてaccuracy, iouを上回った
 
文献：https://arxiv.org/pdf/2106.14917.pdf
コード：https://github.com/PotatoTian/recall-semseg/blob/main/ptsemseg/loss/recall_loss.py